### PR TITLE
Fetch rooms only after preferences are resolved

### DIFF
--- a/frontend/src/components/BookingView.tsx
+++ b/frontend/src/components/BookingView.tsx
@@ -90,14 +90,19 @@ function BookingView(props: BookingViewProps) {
     const [bookings, setBookings] = useState<Booking[]>([]);
 
     useEffect(() => {
-        const buildingPreference = preferences?.building?.id;
-        getRooms(buildingPreference)
-            .then(setRooms)
-            .catch((error) => console.log(error));
+        if (preferences) {
+            const buildingPreference = preferences.building?.id;
+            getRooms(buildingPreference)
+                .then(setRooms)
+                .catch((error) => console.log(error));
+        }
+    }, [preferences]);
+
+    useEffect(() => {
         getBookings()
             .then(setBookings)
             .catch((error) => console.log(error));
-    }, [preferences]);
+    }, []);
 
     const [expandedFeatures, setExpandedFeatures] = React.useState('false');
     const [expandedBooking, setExpandedBooking] = React.useState('false');


### PR DESCRIPTION
Oli sellainen tapaus että kaikkien huoneiden haku kestää sen verran pidempään, että preferenssien kanssa haetut huoneet kerkee palautumaan ensin, ja ylikirjoittaa preferenssien kanssa haetut huoneet.

Tässä korjaus siihen