### PR TITLE
Backend & Frontend - Fix issues with 🕑time zones🕒

### DIFF
--- a/backend/src/controllers/booking/bookingUtils.test.ts
+++ b/backend/src/controllers/booking/bookingUtils.test.ts
@@ -36,10 +36,10 @@ describe('bookingUtils', () => {
         const TEST_EVENTDATA: schema.EventData = {
             id: 'test id',
             start: {
-                dateTime: DateTime.local().toISO()
+                dateTime: DateTime.now().toUTC().toISO()
             },
             end: {
-                dateTime: DateTime.local().plus({ minutes: 60 }).toISO()
+                dateTime: DateTime.now().toUTC().plus({ minutes: 60 }).toISO()
             }
         };
 

--- a/backend/src/controllers/booking/bookingUtils.ts
+++ b/backend/src/controllers/booking/bookingUtils.ts
@@ -3,6 +3,7 @@ import * as admin from '../googleAPI/adminAPI';
 import * as schema from '../../utils/googleSchema';
 import * as responses from '../../utils/responses';
 import { simplifySingleRoomData } from '../roomController';
+import { DateTime } from 'luxon';
 
 /**
  * Simplify the event data to defined type
@@ -27,10 +28,17 @@ export const simplifyEventData = () => {
                 roomId
             );
             const roomData = simplifySingleRoomData(roomResource);
+            const start = DateTime.fromISO(event.start?.dateTime as string)
+                .toUTC()
+                .toISO();
+            const end = DateTime.fromISO(event.end?.dateTime as string)
+                .toUTC()
+                .toISO();
+
             const simpleEvent = {
                 id: event.id,
-                startTime: event.start?.dateTime,
-                endTime: event.end?.dateTime,
+                startTime: start,
+                endTime: end,
                 room: roomData
             };
 

--- a/backend/src/controllers/booking/currentBookingsController.test.ts
+++ b/backend/src/controllers/booking/currentBookingsController.test.ts
@@ -148,60 +148,30 @@ const allCurrentAndFutureBookings: schema.EventsData = {
             id: '1j17pp72bmld5an9abls35p298',
             location: 'Hermia 5-2-Namu-Sofas (10) [TV]',
             start: {
-                dateTime: DateTime.now()
-                    .toUTC()
-                    .setZone('Europe/Helsinki')
-                    .minus({ minutes: 61 })
-                    .toISO(),
-                timeZone: 'Europe/Helsinki'
+                dateTime: DateTime.now().toUTC().minus({ minutes: 61 }).toISO()
             },
             end: {
-                dateTime: DateTime.now()
-                    .toUTC()
-                    .setZone('Europe/Helsinki')
-                    .minus({ minutes: 1 })
-                    .toISO(),
-                timeZone: 'Europe/Helsinki'
+                dateTime: DateTime.now().toUTC().minus({ minutes: 1 }).toISO()
             }
         },
         {
             id: '3pt0pdqmgp0c4qa8a7o4ie0an4',
             location: 'Hakaniemi-7-Höyhen (4) [TV]',
             start: {
-                dateTime: DateTime.now()
-                    .toUTC()
-                    .setZone('Europe/Helsinki')
-                    .minus({ minutes: 30 })
-                    .toISO(),
-                timeZone: 'Europe/Helsinki'
+                dateTime: DateTime.now().toUTC().minus({ minutes: 30 }).toISO()
             },
             end: {
-                dateTime: DateTime.now()
-                    .toUTC()
-                    .setZone('Europe/Helsinki')
-                    .plus({ minutes: 30 })
-                    .toISO(),
-                timeZone: 'Europe/Helsinki'
+                dateTime: DateTime.now().toUTC().plus({ minutes: 30 }).toISO()
             }
         },
         {
             id: '1j17pp72bmld5dsksrpl5jewrt',
             location: 'Arkadia-4-Parlamentti (12) [TV]',
             start: {
-                dateTime: DateTime.now()
-                    .toUTC()
-                    .setZone('Europe/Helsinki')
-                    .plus({ minutes: 1 })
-                    .toISO(),
-                timeZone: 'Europe/Helsinki'
+                dateTime: DateTime.now().toUTC().plus({ minutes: 1 }).toISO()
             },
             end: {
-                dateTime: DateTime.now()
-                    .toUTC()
-                    .setZone('Europe/Helsinki')
-                    .plus({ minutes: 61 })
-                    .toISO(),
-                timeZone: 'Europe/Helsinki'
+                dateTime: DateTime.now().toUTC().plus({ minutes: 61 }).toISO()
             }
         }
     ]

--- a/backend/src/controllers/booking/currentBookingsController.ts
+++ b/backend/src/controllers/booking/currentBookingsController.ts
@@ -136,5 +136,5 @@ export const filterCurrentBookings = (
 };
 
 export const getNowDateTime = (): string => {
-    return DateTime.now().toUTC().setZone('Europe/Helsinki').toISO();
+    return DateTime.now().toUTC().toISO();
 };

--- a/backend/src/controllers/booking/makeBookingController.ts
+++ b/backend/src/controllers/booking/makeBookingController.ts
@@ -75,9 +75,10 @@ export const checkRoomIsFree = () => {
             const client: OAuth2Client = res.locals.oAuthClient;
             const roomId: string = res.locals.roomId;
 
-            const startTime = DateTime.now().toISO();
+            const startTime = DateTime.now().toUTC().toISO();
             const endTime = DateTime.now()
                 .plus({ minutes: res.locals.duration })
+                .toUTC()
                 .toISO();
 
             const freeBusyResult = (
@@ -119,9 +120,10 @@ export const makeBooking = () => {
         next: NextFunction
     ) => {
         try {
-            const startTime = DateTime.now().toISO();
+            const startTime = DateTime.now().toUTC().toISO();
             const endTime = DateTime.now()
                 .plus({ minutes: res.locals.duration })
+                .toUTC()
                 .toISO();
 
             const client: OAuth2Client = res.locals.oAuthClient;

--- a/backend/src/controllers/booking/makeBookingController.ts
+++ b/backend/src/controllers/booking/makeBookingController.ts
@@ -96,7 +96,7 @@ export const checkRoomIsFree = () => {
 
             // freeBusyResult is equal to end time when there are no
             // reservations between now and end time
-            if (DateTime.fromISO(freeBusyResult).toISO() !== endTime) {
+            if (DateTime.fromISO(freeBusyResult).toUTC().toISO() !== endTime) {
                 return responses.custom(req, res, 409, 'Conflict');
             }
 

--- a/backend/src/controllers/booking/updateBookingController.ts
+++ b/backend/src/controllers/booking/updateBookingController.ts
@@ -26,6 +26,7 @@ export const addTimeToBooking = () => {
             // New end time
             const endTime = DateTime.fromISO(eventData.end?.dateTime as string)
                 .plus({ minutes: timeToAdd })
+                .toUTC()
                 .toISO();
 
             // Pretty hacky and there probably is a better way to do this
@@ -73,6 +74,7 @@ export const checkRoomIsFree = () => {
             // New end time
             const endTime = DateTime.fromISO(event.end?.dateTime as string)
                 .plus({ minutes: timeToAdd })
+                .toUTC()
                 .toISO();
 
             const freeBusyResult = (
@@ -127,6 +129,7 @@ export const rollBackDeclinedUpdate = () => {
             // Original end time
             const endTime = DateTime.fromISO(eventData.end?.dateTime as string)
                 .minus({ minutes: timeToAdd })
+                .toUTC()
                 .toISO();
 
             // Pretty hacky and there probably is a better way to do this

--- a/backend/src/controllers/booking/updateBookingController.ts
+++ b/backend/src/controllers/booking/updateBookingController.ts
@@ -92,7 +92,7 @@ export const checkRoomIsFree = () => {
 
             // freeBusyResult is equal to end time when there are no
             // reservations between now and end time
-            if (DateTime.fromISO(freeBusyResult).toISO() !== endTime) {
+            if (DateTime.fromISO(freeBusyResult).toUTC().toISO() !== endTime) {
                 return responses.custom(req, res, 409, 'Conflict');
             }
 

--- a/backend/src/controllers/googleAPI/calendarAPI.ts
+++ b/backend/src/controllers/googleAPI/calendarAPI.ts
@@ -26,10 +26,12 @@ export const createEvent = async (
     end: string
 ): Promise<schema.EventData> => {
     const startDt: schema.EventDateTime = {
-        dateTime: start
+        dateTime: start,
+        timeZone: 'Etc/UTC'
     };
     const endDt: schema.EventDateTime = {
-        dateTime: end
+        dateTime: end,
+        timeZone: 'Etc/UTC'
     };
 
     const attendeeList: schema.EventAttendee[] = [
@@ -122,7 +124,8 @@ export const getCurrentBookings = async (
     const eventsList = await calendar.events.list({
         calendarId: 'primary',
         auth: client,
-        timeMin: now
+        timeMin: now,
+        timeZone: 'Etc/UTC'
     });
 
     return eventsList.data;
@@ -160,7 +163,8 @@ export const updateEndTime = async (
     attendees: schema.EventAttendee[]
 ): Promise<schema.EventData> => {
     const endDt: schema.EventDateTime = {
-        dateTime: endTime
+        dateTime: endTime,
+        timeZone: 'Etc/UTC'
     };
 
     const event = await calendar.events.patch({

--- a/backend/src/controllers/googleAPI/calendarAPI.ts
+++ b/backend/src/controllers/googleAPI/calendarAPI.ts
@@ -117,7 +117,7 @@ export const freeBusyQuery = async (
 export const getCurrentBookings = async (
     client: OAuth2Client
 ): Promise<schema.EventsData> => {
-    const now = DateTime.now().toUTC().setZone('Europe/Helsinki').toISO();
+    const now = DateTime.now().toUTC().toISO();
 
     const eventsList = await calendar.events.list({
         calendarId: 'primary',

--- a/backend/src/controllers/roomController.ts
+++ b/backend/src/controllers/roomController.ts
@@ -72,9 +72,24 @@ export const fetchAvailability = () => {
                 return { id: x.id };
             });
 
-            // TODO: What should happen when the difference is e.g. 1 minute?
-            const start = DateTime.now().toUTC().toISO();
-            const end = DateTime.local().endOf('day').toUTC().toISO();
+            // Custom ending time
+            const customEnd = req.query.until as string;
+            let start, end;
+
+            // TODO: What should happen when the difference between start and end is small
+            if (customEnd) {
+                const startDt = DateTime.now().toUTC();
+                const endDt = DateTime.fromISO(customEnd).toUTC();
+                start = startDt.toISO();
+                end = endDt.toISO();
+
+                if (endDt <= startDt) {
+                    return responses.badRequest(req, res);
+                }
+            } else {
+                start = DateTime.now().toUTC().toISO();
+                end = DateTime.now().toUTC().endOf('day').toISO();
+            }
 
             // Combine all results from freeBusyQuery to this
             const results = {};

--- a/backend/src/controllers/roomController.ts
+++ b/backend/src/controllers/roomController.ts
@@ -72,14 +72,14 @@ export const fetchAvailability = () => {
                 return { id: x.id };
             });
 
-            // Custom ending time
-            const customEnd = req.query.until as string;
-            let start, end;
+            let start: string, end: string;
 
             // TODO: What should happen when the difference between start and end is small
-            if (customEnd) {
+            if (req.query.until) {
                 const startDt = DateTime.now().toUTC();
-                const endDt = DateTime.fromISO(customEnd).toUTC();
+                const endDt = DateTime.fromISO(
+                    req.query.until as string
+                ).toUTC();
                 start = startDt.toISO();
                 end = endDt.toISO();
 

--- a/backend/src/routes/rooms.ts
+++ b/backend/src/routes/rooms.ts
@@ -1,7 +1,8 @@
 import express from 'express';
-import { query } from 'express-validator';
-import * as controller from '../controllers/roomController';
+import { query, validationResult } from 'express-validator';
 import { validateBuildingInOrg } from '../controllers/validateBuildingInOrg';
+import * as controller from '../controllers/roomController';
+import * as responses from '../utils/responses';
 
 export const router = express.Router();
 
@@ -9,7 +10,14 @@ export const router = express.Router();
 router.get(
     '/',
     query('showReserved').toBoolean(),
-    query('building').trim().escape(),
+    query('building').trim().escape().isString().optional({ nullable: true }),
+    query('until').trim().escape().isISO8601().optional({ nullable: true }),
+    (req, res, next) => {
+        if (!validationResult(req).isEmpty()) {
+            return responses.badRequest(req, res);
+        }
+        next();
+    },
     validateBuildingInOrg(),
     controller.addAllRooms(),
     controller.fetchAvailability(),

--- a/frontend/src/components/util/TimeLeft.tsx
+++ b/frontend/src/components/util/TimeLeft.tsx
@@ -3,8 +3,8 @@ import React, { useEffect, useState } from 'react';
 import { DateTime, Duration } from 'luxon';
 
 function getTimeLeft(endTime: string) {
-    let endOfDay = DateTime.now().endOf('day');
-    let nextReservationTime = DateTime.fromISO(endTime);
+    let endOfDay = DateTime.local().endOf('day').toUTC();
+    let nextReservationTime = DateTime.fromISO(endTime).toUTC();
 
     // If nextReservationTime equals to end of the day, then that means that the
     // room has no current reservations for that day and is free all day.
@@ -12,7 +12,7 @@ function getTimeLeft(endTime: string) {
         return 'All day';
     }
 
-    let currentTime = DateTime.now();
+    let currentTime = DateTime.local().toUTC();
 
     let duration = Duration.fromObject(
         nextReservationTime.diff(currentTime, ['hours', 'minutes']).toObject()

--- a/frontend/src/components/util/TimeLeft.tsx
+++ b/frontend/src/components/util/TimeLeft.tsx
@@ -6,17 +6,15 @@ function getTimeLeft(endTime: string) {
     let endOfDay = DateTime.local().endOf('day').toUTC();
     let nextReservationTime = DateTime.fromISO(endTime).toUTC();
 
+    let duration = Duration.fromObject(
+        nextReservationTime.diffNow(['hours', 'minutes']).toObject()
+    );
+
     // If nextReservationTime equals to end of the day, then that means that the
     // room has no current reservations for that day and is free all day.
-    if (nextReservationTime.equals(endOfDay)) {
+    if (nextReservationTime.equals(endOfDay) || duration.hours >= 24) {
         return 'All day';
     }
-
-    let currentTime = DateTime.local().toUTC();
-
-    let duration = Duration.fromObject(
-        nextReservationTime.diff(currentTime, ['hours', 'minutes']).toObject()
-    );
 
     if (duration.hours === 0 && duration.minutes < 1) {
         return '< 1 min';

--- a/frontend/src/services/roomService.ts
+++ b/frontend/src/services/roomService.ts
@@ -16,7 +16,15 @@ export const getRooms = async (
 
     // Add local end of day as end time for room availability lookup
     // Should this be moved somewhere else?
-    urlParams.append('until', DateTime.local().endOf('day').toUTC().toISO());
+    let endTime = DateTime.local().endOf('day').toUTC();
+
+    // If under 60 minutes left of a day, set end to next days end of day
+    // as backend doesn't return rooms with less than 30 minutes of availability
+    if (endTime.diffNow(['minutes']).minutes <= 60) {
+        endTime = endTime.plus({ days: 1 }).toUTC();
+    }
+
+    urlParams.append('until', endTime.toISO());
 
     const response = await axios.get('/rooms', { params: urlParams });
     return response.data.rooms;

--- a/frontend/src/services/roomService.ts
+++ b/frontend/src/services/roomService.ts
@@ -1,4 +1,5 @@
 import { Room } from '../types';
+import { DateTime } from 'luxon';
 import axios from './axiosConfigurer';
 
 export const getRooms = async (
@@ -12,6 +13,10 @@ export const getRooms = async (
     if (showReserved) {
         urlParams.append('showReserved', showReserved.toString());
     }
+
+    // Add local end of day as end time for room availability lookup
+    // Should this be moved somewhere else?
+    urlParams.append('until', DateTime.local().endOf('day').toUTC().toISO());
 
     const response = await axios.get('/rooms', { params: urlParams });
     return response.data.rooms;


### PR DESCRIPTION
# Korjataan aikavyöhykkeet🌎🌍🌏
Yritetään korjata kaikki aikavyöhykkeisiin liittyvät ongelmat tässä niin ei tarvitse enää miettiä tulevaisuudessa :-)

## Tehty
### Backend
- Muutettu kaikki DateTimet sisältämään `toUTC()`
- Poistettu viittaukset aikavyöhykkeisiin eli kaikki `setZone('Europe/Helsinki)`
- Korjattu tämän testeissä aiheuttamat ongelmat
- Lisätty Googlen Calendar API kutsuihin tarkennus `timeZone: 'Etc/UTC'`
- Lisätty `/rooms`-endpointtiin `until`-parametri
  - Pitäisikö tälle keksiä parempi nimi?🤔 Mielipiteitä?
  - Vapaaehtoinen
  - Olettaa parametrin olevan ISO8601 DateTime string, esim. `2021-11-18T21:59:59Z`
  - Jos annettu, käytetään `freeBusyQuery`:n takarajana eli haettava väli on nyt -> until
  - Jos ei annettu, käytetään takarajana tämän hetkisen UTC-päivän kellonaikaa 23.59.59
- Mahdollisesti muita pieniä korjauksia joita en muista :D

### Frontend
- Muokattu `getRooms` käyttämään uutta `until`-parametria
  - Onko tämä oikea paikka tälle vai olisiko parempi olla jossain muualla?
  - Asettaa `until` arvoksi (käyttäjän selaimen?) local-ajan 23.59.59 muutettuna UTC-ajaksi
  - Johtuen backendin logiikasta (ei palauteta huoneita mikäli alle 30 min vapaata), jouduin tekemään muutoksen, jossa ~~30~~ 60 min ennen päivän vaihtumista haut tehdään oikeasti huomiseen iltaan asti
    - Muutin myös `Free for: All day` logiikan vastaamaan tätä eli tilanteissa joissa `difference`:n tunteja on 24 tai yli niin näytetään myös tuo `All day`
- Muutettu `getTimeLeft` sisällä ajat UTC-ajoiksi
  - Tällä ei käytännössä ollut toimintaan merkitystä ja toimi hyvin ilmankin, mutta ajattelin yhtenäisyyden nimissä laittaa näin
