### PR TITLE
Make notifications dismissable

### DIFF
--- a/frontend/src/hooks/useCreateNotification.tsx
+++ b/frontend/src/hooks/useCreateNotification.tsx
@@ -1,28 +1,42 @@
+import { IconButton } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
 import { useSnackbar } from 'notistack';
 
 type NotificationType = 'default' | 'error' | 'success' | 'warning' | 'info';
 
 const useCreateNotification = () => {
-    const { enqueueSnackbar } = useSnackbar();
+    const { enqueueSnackbar, closeSnackbar } = useSnackbar();
+
+    const closeAction = (key: number) => {
+        return (
+            <IconButton onClick={() => closeSnackbar(key)}>
+                <CloseIcon />
+            </IconButton>
+        );
+    };
 
     const createNotificationWithType = (
         message: string,
         type: NotificationType
     ) => {
         enqueueSnackbar(message, {
-            variant: type
+            variant: type,
+            action: closeAction
         });
     };
 
     const createSuccessNotification = (message: string) => {
         enqueueSnackbar(message, {
-            variant: 'success'
+            variant: 'success',
+            action: closeAction
         });
     };
 
     const createErrorNotification = (message: string) => {
         enqueueSnackbar(message, {
-            variant: 'error'
+            variant: 'error',
+            action: closeAction,
+            autoHideDuration: 30000
         });
     };
 

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -11,5 +11,8 @@ export const theme = createTheme({
         h3: { color: ORANGE },
         h4: { color: ORANGE, fontWeight: 'bold' },
         h5: { color: ORANGE, fontWeight: 'bold' }
+    },
+    zIndex: {
+        snackbar: 1
     }
 });


### PR DESCRIPTION
- Increase error notification auto hide duration
- Notifications are dismissable
- Notifications are now "under" appbar, before you could not click appbar menu elements when a notification was present